### PR TITLE
update: return API embedding response

### DIFF
--- a/cmd/cohere/main.go
+++ b/cmd/cohere/main.go
@@ -35,7 +35,12 @@ func main() {
 		Truncate:  cohere.Truncate(truncate),
 	}
 
-	embs, err := c.Embeddings(context.Background(), embReq)
+	embResp, err := c.Embeddings(context.Background(), embReq)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	embs, err := cohere.ToEmbeddings(embResp)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/openai/main.go
+++ b/cmd/openai/main.go
@@ -32,7 +32,12 @@ func main() {
 		EncodingFormat: openai.EncodingFormat(encoding),
 	}
 
-	embs, err := c.Embeddings(context.Background(), embReq)
+	embResp, err := c.Embeddings(context.Background(), embReq)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	embs, err := openai.ToEmbeddings(embResp)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/vertexai/main.go
+++ b/cmd/vertexai/main.go
@@ -53,7 +53,12 @@ func main() {
 		},
 	}
 
-	embs, err := c.Embeddings(context.Background(), embReq)
+	embResp, err := c.Embeddings(context.Background(), embReq)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	embs, err := vertexai.ToEmbeddings(embResp)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/embedding.go
+++ b/embedding.go
@@ -1,0 +1,15 @@
+package embeddings
+
+// Embedding is vector embedding.
+type Embedding struct {
+	Vector []float64 `json:"vector"`
+}
+
+// ToFloat32 returns Embedding verctor as a slice of float32.
+func (e Embedding) ToFloat32() []float32 {
+	floats := make([]float32, 0, len(e.Vector))
+	for _, f := range e.Vector {
+		floats = append(floats, float32(f))
+	}
+	return floats
+}


### PR DESCRIPTION
Originally Embeddings method would return an object which was a result of a conversion to a smaller type which only contained the embeddings. This prevents the clients from accessing the API response fields which is not ideal.

This commit reverts to returning deserialized API responses and instead provides an exported func in each package that lets the consumers to convert the object into a higher level embedding type defined in the module root.