### PR TITLE
feat: introduce Embedder interface

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,0 +1,9 @@
+package embeddings
+
+import "context"
+
+// Embedder fetches embeddings.
+type Embedder[T any] interface {
+	// Embeddings fetches embeddings and returns them.
+	Embeddings(context.Context, T) ([]*Embedding, error)
+}

--- a/cmd/cohere/main.go
+++ b/cmd/cohere/main.go
@@ -35,12 +35,7 @@ func main() {
 		Truncate:  cohere.Truncate(truncate),
 	}
 
-	embResp, err := c.Embeddings(context.Background(), embReq)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	embs, err := embResp.ToEmbeddings()
+	embs, err := c.Embeddings(context.Background(), embReq)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/openai/main.go
+++ b/cmd/openai/main.go
@@ -32,12 +32,7 @@ func main() {
 		EncodingFormat: openai.EncodingFormat(encoding),
 	}
 
-	embResp, err := c.Embeddings(context.Background(), embReq)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	embs, err := embResp.ToEmbeddings()
+	embs, err := c.Embeddings(context.Background(), embReq)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/vertexai/main.go
+++ b/cmd/vertexai/main.go
@@ -36,9 +36,9 @@ func main() {
 		log.Fatalf("token source: %v", err)
 	}
 
-	c := vertexai.NewClient().
-		WithTokenSrc(ts).
-		WithModelID(model)
+	c := vertexai.NewClient(
+		vertexai.WithTokenSrc(ts),
+		vertexai.WithModelID(model))
 
 	embReq := &vertexai.EmbeddingRequest{
 		Instances: []vertexai.Instance{

--- a/cmd/vertexai/main.go
+++ b/cmd/vertexai/main.go
@@ -53,12 +53,7 @@ func main() {
 		},
 	}
 
-	embResp, err := c.Embeddings(context.Background(), embReq)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	embs, err := embResp.ToEmbeddings()
+	embs, err := c.Embeddings(context.Background(), embReq)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cohere/client.go
+++ b/cohere/client.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"os"
+
+	"github.com/milosgajdos/go-embeddings"
 )
 
 const (
@@ -32,6 +34,11 @@ func NewClient() *Client {
 		version: EmbedAPIVersion,
 		hc:      &http.Client{},
 	}
+}
+
+// NewEmbedder creates a client that implements embeddings.Embedder
+func NewEmbedder() embeddings.Embedder[*EmbeddingRequest] {
+	return NewClient()
 }
 
 // WithAPIKey sets the API key.

--- a/cohere/client_test.go
+++ b/cohere/client_test.go
@@ -16,37 +16,37 @@ func TestClient(t *testing.T) {
 
 	t.Run("API key", func(t *testing.T) {
 		c := NewClient()
-		assert.Equal(t, c.apiKey, cohereAPIKey)
+		assert.Equal(t, c.opts.APIKey, cohereAPIKey)
 
 		testVal := "foo"
-		c.WithAPIKey(testVal)
-		assert.Equal(t, c.apiKey, testVal)
+		c = NewClient(WithAPIKey(testVal))
+		assert.Equal(t, c.opts.APIKey, testVal)
 	})
 
 	t.Run("BaseURL", func(t *testing.T) {
 		c := NewClient()
-		assert.Equal(t, c.baseURL, BaseURL)
+		assert.Equal(t, c.opts.BaseURL, BaseURL)
 
 		testVal := "http://foo"
-		c.WithBaseURL(testVal)
-		assert.Equal(t, c.baseURL, testVal)
+		c = NewClient(WithBaseURL(testVal))
+		assert.Equal(t, c.opts.BaseURL, testVal)
 	})
 
 	t.Run("version", func(t *testing.T) {
 		c := NewClient()
-		assert.Equal(t, c.version, EmbedAPIVersion)
+		assert.Equal(t, c.opts.Version, EmbedAPIVersion)
 
 		testVal := "v3"
-		c.WithVersion(testVal)
-		assert.Equal(t, c.version, testVal)
+		c = NewClient(WithVersion(testVal))
+		assert.Equal(t, c.opts.Version, testVal)
 	})
 
 	t.Run("http client", func(t *testing.T) {
 		c := NewClient()
-		assert.NotNil(t, c.hc)
+		assert.NotNil(t, c.opts.HTTPClient)
 
 		testVal := &http.Client{}
-		c.WithHTTPClient(testVal)
-		assert.NotNil(t, c.hc)
+		c = NewClient(WithHTTPClient(testVal))
+		assert.NotNil(t, c.opts.HTTPClient)
 	})
 }

--- a/cohere/embedding.go
+++ b/cohere/embedding.go
@@ -51,7 +51,7 @@ type APIVersion struct {
 }
 
 // Embeddings returns embeddings for every object in EmbeddingRequest.
-func (c *Client) Embeddings(ctx context.Context, embReq *EmbeddingRequest) (*EmbedddingResponse, error) {
+func (c *Client) Embeddings(ctx context.Context, embReq *EmbeddingRequest) ([]*embeddings.Embedding, error) {
 	u, err := url.Parse(c.baseURL + "/" + c.version + "/embed")
 	if err != nil {
 		return nil, err
@@ -84,5 +84,5 @@ func (c *Client) Embeddings(ctx context.Context, embReq *EmbeddingRequest) (*Emb
 		return nil, err
 	}
 
-	return e, nil
+	return e.ToEmbeddings()
 }

--- a/cohere/embedding.go
+++ b/cohere/embedding.go
@@ -52,7 +52,7 @@ type APIVersion struct {
 
 // Embeddings returns embeddings for every object in EmbeddingRequest.
 func (c *Client) Embeddings(ctx context.Context, embReq *EmbeddingRequest) ([]*embeddings.Embedding, error) {
-	u, err := url.Parse(c.baseURL + "/" + c.version + "/embed")
+	u, err := url.Parse(c.opts.BaseURL + "/" + c.opts.Version + "/embed")
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func (c *Client) Embeddings(ctx context.Context, embReq *EmbeddingRequest) ([]*e
 	}
 
 	options := []request.Option{
-		request.WithBearer(c.apiKey),
+		request.WithBearer(c.opts.APIKey),
 	}
 
 	req, err := request.NewHTTP(ctx, http.MethodPost, u.String(), body, options...)

--- a/openai/client.go
+++ b/openai/client.go
@@ -19,64 +19,83 @@ const (
 
 // Client is an OpenAI HTTP API client.
 type Client struct {
-	apiKey  string
-	baseURL string
-	version string
-	orgID   string
-	hc      *http.Client
+	opts Options
 }
+
+type Options struct {
+	APIKey     string
+	BaseURL    string
+	Version    string
+	OrgID      string
+	HTTPClient *http.Client
+}
+
+// Option is functional graph option.
+type Option func(*Options)
 
 // NewClient creates a new HTTP API client and returns it.
 // By default it reads the OpenAI API key from OPENAI_API_KEY
 // env var and uses the default Go http.Client for making API requests.
 // You can override the default options via the client methods.
-func NewClient() *Client {
+func NewClient(opts ...Option) *Client {
+	options := Options{
+		APIKey:     os.Getenv("OPENAI_API_KEY"),
+		BaseURL:    BaseURL,
+		Version:    EmbedAPIVersion,
+		HTTPClient: &http.Client{},
+	}
+
+	for _, apply := range opts {
+		apply(&options)
+	}
+
 	return &Client{
-		apiKey:  os.Getenv("OPENAI_API_KEY"),
-		baseURL: BaseURL,
-		version: EmbedAPIVersion,
-		orgID:   "",
-		hc:      &http.Client{},
+		opts: options,
 	}
 }
 
 // NewEmbedder creates a client that implements embeddings.Embedder
-func NewEmbedder() embeddings.Embedder[*EmbeddingRequest] {
-	return NewClient()
+func NewEmbedder(opts ...Option) embeddings.Embedder[*EmbeddingRequest] {
+	return NewClient(opts...)
 }
 
 // WithAPIKey sets the API key.
-func (c *Client) WithAPIKey(apiKey string) *Client {
-	c.apiKey = apiKey
-	return c
+func WithAPIKey(apiKey string) Option {
+	return func(o *Options) {
+		o.APIKey = apiKey
+	}
 }
 
 // WithBaseURL sets the API base URL.
-func (c *Client) WithBaseURL(baseURL string) *Client {
-	c.baseURL = baseURL
-	return c
+func WithBaseURL(baseURL string) Option {
+	return func(o *Options) {
+		o.BaseURL = baseURL
+	}
 }
 
 // WithVersion sets the API version.
-func (c *Client) WithVersion(version string) *Client {
-	c.version = version
-	return c
+func WithVersion(version string) Option {
+	return func(o *Options) {
+		o.Version = version
+	}
 }
 
 // WithOrgID sets the organization ID.
-func (c *Client) WithOrgID(orgID string) *Client {
-	c.orgID = orgID
-	return c
+func WithOrgID(orgID string) Option {
+	return func(o *Options) {
+		o.OrgID = orgID
+	}
 }
 
 // WithHTTPClient sets the HTTP client.
-func (c *Client) WithHTTPClient(httpClient *http.Client) *Client {
-	c.hc = httpClient
-	return c
+func WithHTTPClient(httpClient *http.Client) Option {
+	return func(o *Options) {
+		o.HTTPClient = httpClient
+	}
 }
 
 func (c *Client) doRequest(req *http.Request) (*http.Response, error) {
-	resp, err := c.hc.Do(req)
+	resp, err := c.opts.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/openai/client.go
+++ b/openai/client.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"os"
+
+	"github.com/milosgajdos/go-embeddings"
 )
 
 const (
@@ -36,6 +38,11 @@ func NewClient() *Client {
 		orgID:   "",
 		hc:      &http.Client{},
 	}
+}
+
+// NewEmbedder creates a client that implements embeddings.Embedder
+func NewEmbedder() embeddings.Embedder[*EmbeddingRequest] {
+	return NewClient()
 }
 
 // WithAPIKey sets the API key.

--- a/openai/client_test.go
+++ b/openai/client_test.go
@@ -16,46 +16,46 @@ func TestClient(t *testing.T) {
 
 	t.Run("API key", func(t *testing.T) {
 		c := NewClient()
-		assert.Equal(t, c.apiKey, openaiKey)
+		assert.Equal(t, c.opts.APIKey, openaiKey)
 
 		testVal := "foo"
-		c.WithAPIKey(testVal)
-		assert.Equal(t, c.apiKey, testVal)
+		c = NewClient(WithAPIKey(testVal))
+		assert.Equal(t, c.opts.APIKey, testVal)
 	})
 
 	t.Run("BaseURL", func(t *testing.T) {
 		c := NewClient()
-		assert.Equal(t, c.baseURL, BaseURL)
+		assert.Equal(t, c.opts.BaseURL, BaseURL)
 
 		testVal := "http://foo"
-		c.WithBaseURL(testVal)
-		assert.Equal(t, c.baseURL, testVal)
+		c = NewClient(WithBaseURL(testVal))
+		assert.Equal(t, c.opts.BaseURL, testVal)
 	})
 
 	t.Run("version", func(t *testing.T) {
 		c := NewClient()
-		assert.Equal(t, c.version, EmbedAPIVersion)
+		assert.Equal(t, c.opts.Version, EmbedAPIVersion)
 
 		testVal := "v3"
-		c.WithVersion(testVal)
-		assert.Equal(t, c.version, testVal)
+		c = NewClient(WithVersion(testVal))
+		assert.Equal(t, c.opts.Version, testVal)
 	})
 
 	t.Run("orgID", func(t *testing.T) {
 		c := NewClient()
-		assert.Equal(t, c.orgID, "")
+		assert.Equal(t, c.opts.OrgID, "")
 
 		testVal := "orgID"
-		c.WithOrgID(testVal)
-		assert.Equal(t, c.orgID, testVal)
+		c = NewClient(WithOrgID(testVal))
+		assert.Equal(t, c.opts.OrgID, testVal)
 	})
 
 	t.Run("http client", func(t *testing.T) {
 		c := NewClient()
-		assert.NotNil(t, c.hc)
+		assert.NotNil(t, c.opts.HTTPClient)
 
 		testVal := &http.Client{}
-		c.WithHTTPClient(testVal)
-		assert.NotNil(t, c.hc)
+		c = NewClient(WithHTTPClient(testVal))
+		assert.NotNil(t, c.opts.HTTPClient)
 	})
 }

--- a/openai/embedding.go
+++ b/openai/embedding.go
@@ -145,7 +145,7 @@ func toEmbeddingResp[T any](resp io.Reader) (*EmbeddingResponse, error) {
 
 // Embeddings returns embeddings for every object in EmbeddingRequest.
 func (c *Client) Embeddings(ctx context.Context, embReq *EmbeddingRequest) ([]*embeddings.Embedding, error) {
-	u, err := url.Parse(c.baseURL + "/" + c.version + "/embeddings")
+	u, err := url.Parse(c.opts.BaseURL + "/" + c.opts.Version + "/embeddings")
 	if err != nil {
 		return nil, err
 	}
@@ -158,10 +158,10 @@ func (c *Client) Embeddings(ctx context.Context, embReq *EmbeddingRequest) ([]*e
 	}
 
 	options := []request.Option{
-		request.WithBearer(c.apiKey),
+		request.WithBearer(c.opts.APIKey),
 	}
-	if c.orgID != "" {
-		options = append(options, request.WithSetHeader(OrgHeader, c.orgID))
+	if c.opts.OrgID != "" {
+		options = append(options, request.WithSetHeader(OrgHeader, c.opts.OrgID))
 	}
 
 	req, err := request.NewHTTP(ctx, http.MethodPost, u.String(), body, options...)

--- a/vertexai/client.go
+++ b/vertexai/client.go
@@ -20,13 +20,21 @@ const (
 
 // Client is a Google Vertex AI HTTP API client.
 type Client struct {
-	token     string
-	tokenSrc  oauth2.TokenSource
-	projectID string
-	modelID   string
-	baseURL   string
-	hc        *http.Client
+	opts Options
 }
+
+// Options are client options
+type Options struct {
+	Token      string
+	TokenSrc   oauth2.TokenSource
+	ProjectID  string
+	ModelID    string
+	BaseURL    string
+	HTTPClient *http.Client
+}
+
+// Option is functional graph option.
+type Option func(*Options)
 
 // NewClient creates a new HTTP client and returns it.
 // By default it reads the following env vars:
@@ -37,62 +45,76 @@ type Client struct {
 // to the BaseURL. You can override the default client options
 // via the client methods.
 // NOTE: you must provide either the token or the token source
-func NewClient() *Client {
+func NewClient(opts ...Option) *Client {
+	options := Options{
+		Token:      os.Getenv("VERTEXAI_TOKEN"),
+		ModelID:    os.Getenv("VERTEXAI_MODEL_ID"),
+		ProjectID:  os.Getenv("GOOGLE_PROJECT_ID"),
+		BaseURL:    BaseURL,
+		HTTPClient: &http.Client{},
+	}
+
+	for _, apply := range opts {
+		apply(&options)
+	}
+
 	return &Client{
-		token:     os.Getenv("VERTEXAI_TOKEN"),
-		modelID:   os.Getenv("VERTEXAI_MODEL_ID"),
-		projectID: os.Getenv("GOOGLE_PROJECT_ID"),
-		baseURL:   BaseURL,
-		hc:        &http.Client{},
+		opts: options,
 	}
 }
 
 // NewEmbedder creates a client that implements embeddings.Embedder
-func NewEmbedder() embeddings.Embedder[*EmbeddingRequest] {
-	return NewClient()
+func NewEmbedder(opts ...Option) embeddings.Embedder[*EmbeddingRequest] {
+	return NewClient(opts...)
 }
 
 // WithToken sets the API token.
-func (c *Client) WithToken(token string) *Client {
-	c.token = token
-	return c
+func WithToken(token string) Option {
+	return func(o *Options) {
+		o.Token = token
+	}
 }
 
 // WithTokenSrc sets the API token source.
 // The source can be used for generating the API token
 // if no token has been set.
-func (c *Client) WithTokenSrc(ts oauth2.TokenSource) *Client {
-	c.tokenSrc = ts
-	return c
+func WithTokenSrc(ts oauth2.TokenSource) Option {
+	return func(o *Options) {
+		o.TokenSrc = ts
+	}
 }
 
 // WithProjectID sets the Google Project ID.
-func (c *Client) WithProjectID(id string) *Client {
-	c.projectID = id
-	return c
+func WithProjectID(id string) Option {
+	return func(o *Options) {
+		o.ProjectID = id
+	}
 }
 
 // WithModelID sets the Vertex AI model ID.
 // https://cloud.google.com/vertex-ai/docs/generative-ai/learn/model-versioning
-func (c *Client) WithModelID(id string) *Client {
-	c.modelID = id
-	return c
+func WithModelID(id string) Option {
+	return func(o *Options) {
+		o.ModelID = id
+	}
 }
 
 // WithBaseURL sets the API base URL.
-func (c *Client) WithBaseURL(baseURL string) *Client {
-	c.baseURL = baseURL
-	return c
+func WithBaseURL(baseURL string) Option {
+	return func(o *Options) {
+		o.BaseURL = baseURL
+	}
 }
 
 // WithHTTPClient sets the HTTP client.
-func (c *Client) WithHTTPClient(httpClient *http.Client) *Client {
-	c.hc = httpClient
-	return c
+func WithHTTPClient(httpClient *http.Client) Option {
+	return func(o *Options) {
+		o.HTTPClient = httpClient
+	}
 }
 
 func (c *Client) doRequest(req *http.Request) (*http.Response, error) {
-	resp, err := c.hc.Do(req)
+	resp, err := c.opts.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/vertexai/client.go
+++ b/vertexai/client.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/milosgajdos/go-embeddings"
 	"golang.org/x/oauth2"
 )
 
@@ -44,6 +45,11 @@ func NewClient() *Client {
 		baseURL:   BaseURL,
 		hc:        &http.Client{},
 	}
+}
+
+// NewEmbedder creates a client that implements embeddings.Embedder
+func NewEmbedder() embeddings.Embedder[*EmbeddingRequest] {
+	return NewClient()
 }
 
 // WithToken sets the API token.

--- a/vertexai/client_test.go
+++ b/vertexai/client_test.go
@@ -29,55 +29,55 @@ func TestClient(t *testing.T) {
 
 	t.Run("token", func(t *testing.T) {
 		c := NewClient()
-		assert.Equal(t, c.token, vertexaiToken)
+		assert.Equal(t, c.opts.Token, vertexaiToken)
 
 		testVal := "foo"
-		c.WithToken(testVal)
-		assert.Equal(t, c.token, testVal)
+		c = NewClient(WithToken(testVal))
+		assert.Equal(t, c.opts.Token, testVal)
 	})
 
 	t.Run("token source", func(t *testing.T) {
 		c := NewClient()
-		assert.Nil(t, c.tokenSrc)
+		assert.Nil(t, c.opts.TokenSrc)
 
 		ts := &ts{token: "foo"}
-		c.WithTokenSrc(ts)
-		assert.NotNil(t, c.tokenSrc)
+		c = NewClient(WithTokenSrc(ts))
+		assert.NotNil(t, c.opts.TokenSrc)
 	})
 
 	t.Run("project id", func(t *testing.T) {
 		c := NewClient()
-		assert.Equal(t, c.projectID, googleProjectID)
+		assert.Equal(t, c.opts.ProjectID, googleProjectID)
 
 		testVal := "id"
-		c.WithProjectID(testVal)
-		assert.Equal(t, c.projectID, testVal)
+		c = NewClient(WithProjectID(testVal))
+		assert.Equal(t, c.opts.ProjectID, testVal)
 	})
 
 	t.Run("model id", func(t *testing.T) {
 		c := NewClient()
-		assert.Equal(t, c.modelID, vertexaiMoel)
+		assert.Equal(t, c.opts.ModelID, vertexaiMoel)
 
 		testVal := "id"
-		c.WithProjectID(testVal)
-		assert.Equal(t, c.modelID, vertexaiMoel)
+		c = NewClient(WithProjectID(testVal))
+		assert.Equal(t, c.opts.ModelID, vertexaiMoel)
 	})
 
 	t.Run("BaseURL", func(t *testing.T) {
 		c := NewClient()
-		assert.Equal(t, c.baseURL, BaseURL)
+		assert.Equal(t, c.opts.BaseURL, BaseURL)
 
 		testVal := "http://foo"
-		c.WithBaseURL(testVal)
-		assert.Equal(t, c.baseURL, testVal)
+		c = NewClient(WithBaseURL(testVal))
+		assert.Equal(t, c.opts.BaseURL, testVal)
 	})
 
 	t.Run("http client", func(t *testing.T) {
 		c := NewClient()
-		assert.NotNil(t, c.hc)
+		assert.NotNil(t, c.opts.HTTPClient)
 
 		testVal := &http.Client{}
-		c.WithHTTPClient(testVal)
-		assert.NotNil(t, c.hc)
+		c = NewClient(WithHTTPClient(testVal))
+		assert.NotNil(t, c.opts.HTTPClient)
 	})
 }

--- a/vertexai/embedding.go
+++ b/vertexai/embedding.go
@@ -70,7 +70,7 @@ type Statistics struct {
 }
 
 // Embeddings returns embeddings for every object in EmbeddingRequest.
-func (c *Client) Embeddings(ctx context.Context, embReq *EmbeddingRequest) (*EmbedddingResponse, error) {
+func (c *Client) Embeddings(ctx context.Context, embReq *EmbeddingRequest) ([]*embeddings.Embedding, error) {
 	u, err := url.Parse(c.baseURL + "/" + c.projectID + "/" + ModelURI + "/" + c.modelID + EmbedAction)
 	if err != nil {
 		return nil, err
@@ -111,5 +111,5 @@ func (c *Client) Embeddings(ctx context.Context, embReq *EmbeddingRequest) (*Emb
 		return nil, err
 	}
 
-	return e, nil
+	return e.ToEmbeddings()
 }

--- a/vertexai/embedding.go
+++ b/vertexai/embedding.go
@@ -71,7 +71,7 @@ type Statistics struct {
 
 // Embeddings returns embeddings for every object in EmbeddingRequest.
 func (c *Client) Embeddings(ctx context.Context, embReq *EmbeddingRequest) ([]*embeddings.Embedding, error) {
-	u, err := url.Parse(c.baseURL + "/" + c.projectID + "/" + ModelURI + "/" + c.modelID + EmbedAction)
+	u, err := url.Parse(c.opts.BaseURL + "/" + c.opts.ProjectID + "/" + ModelURI + "/" + c.opts.ModelID + EmbedAction)
 	if err != nil {
 		return nil, err
 	}
@@ -83,16 +83,16 @@ func (c *Client) Embeddings(ctx context.Context, embReq *EmbeddingRequest) ([]*e
 		return nil, err
 	}
 
-	if c.token == "" {
+	if c.opts.Token == "" {
 		var err error
-		c.token, err = GetToken(c.tokenSrc)
+		c.opts.Token, err = GetToken(c.opts.TokenSrc)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	options := []request.Option{
-		request.WithBearer(c.token),
+		request.WithBearer(c.opts.Token),
 	}
 
 	req, err := request.NewHTTP(ctx, http.MethodPost, u.String(), body, options...)

--- a/vertexai/multi_embedding.go
+++ b/vertexai/multi_embedding.go
@@ -51,7 +51,7 @@ type MultiPrediction struct {
 
 // MultiEmbeddings returns multimodal embeddings for every object in EmbeddingRequest.
 func (c *Client) MultiEmbeddings(ctx context.Context, embReq *MultiEmbeddingRequest) (*MultiEmbedddingResponse, error) {
-	u, err := url.Parse(c.baseURL + "/" + c.projectID + "/" + ModelURI + "/" + c.modelID + EmbedAction)
+	u, err := url.Parse(c.opts.BaseURL + "/" + c.opts.ProjectID + "/" + ModelURI + "/" + c.opts.ModelID + EmbedAction)
 	if err != nil {
 		return nil, err
 	}
@@ -63,16 +63,16 @@ func (c *Client) MultiEmbeddings(ctx context.Context, embReq *MultiEmbeddingRequ
 		return nil, err
 	}
 
-	if c.token == "" {
+	if c.opts.Token == "" {
 		var err error
-		c.token, err = GetToken(c.tokenSrc)
+		c.opts.Token, err = GetToken(c.opts.TokenSrc)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	options := []request.Option{
-		request.WithBearer(c.token),
+		request.WithBearer(c.opts.Token),
 	}
 
 	req, err := request.NewHTTP(ctx, http.MethodPost, u.String(), body, options...)


### PR DESCRIPTION
This lets you make the API client generic when instantiated with `NewEmbedder` funcs. 

This needs a bit more thinking and cleaning up. We should make the `doRequest` generic, too, to avoid duplication.