### PR TITLE
update: add Do to request package and remove cruft

### DIFF
--- a/cohere/client.go
+++ b/cohere/client.go
@@ -1,7 +1,6 @@
 package cohere
 
 import (
-	"encoding/json"
 	"net/http"
 	"os"
 
@@ -83,22 +82,4 @@ func WithHTTPClient(httpClient *http.Client) Option {
 	return func(o *Options) {
 		o.HTTPClient = httpClient
 	}
-}
-
-func (c *Client) doRequest(req *http.Request) (*http.Response, error) {
-	resp, err := c.opts.HTTPClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusBadRequest {
-		return resp, nil
-	}
-	defer resp.Body.Close()
-
-	var apiErr APIError
-	if err := json.NewDecoder(resp.Body).Decode(&apiErr); err != nil {
-		return nil, err
-	}
-
-	return nil, apiErr
 }

--- a/cohere/embedding.go
+++ b/cohere/embedding.go
@@ -73,7 +73,7 @@ func (c *Client) Embed(ctx context.Context, embReq *EmbeddingRequest) ([]*embedd
 		return nil, err
 	}
 
-	resp, err := c.doRequest(req)
+	resp, err := request.Do[APIError](c.opts.HTTPClient, req)
 	if err != nil {
 		return nil, err
 	}

--- a/openai/client.go
+++ b/openai/client.go
@@ -1,7 +1,6 @@
 package openai
 
 import (
-	"encoding/json"
 	"net/http"
 	"os"
 
@@ -92,22 +91,4 @@ func WithHTTPClient(httpClient *http.Client) Option {
 	return func(o *Options) {
 		o.HTTPClient = httpClient
 	}
-}
-
-func (c *Client) doRequest(req *http.Request) (*http.Response, error) {
-	resp, err := c.opts.HTTPClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusBadRequest {
-		return resp, nil
-	}
-	defer resp.Body.Close()
-
-	var apiErr APIError
-	if err := json.NewDecoder(resp.Body).Decode(&apiErr); err != nil {
-		return nil, err
-	}
-
-	return nil, apiErr
 }

--- a/openai/embedding.go
+++ b/openai/embedding.go
@@ -169,7 +169,7 @@ func (c *Client) Embed(ctx context.Context, embReq *EmbeddingRequest) ([]*embedd
 		return nil, err
 	}
 
-	resp, err := c.doRequest(req)
+	resp, err := request.Do[APIError](c.opts.HTTPClient, req)
 	if err != nil {
 		return nil, err
 	}

--- a/vertexai/client.go
+++ b/vertexai/client.go
@@ -1,7 +1,6 @@
 package vertexai
 
 import (
-	"encoding/json"
 	"net/http"
 	"os"
 
@@ -111,22 +110,4 @@ func WithHTTPClient(httpClient *http.Client) Option {
 	return func(o *Options) {
 		o.HTTPClient = httpClient
 	}
-}
-
-func (c *Client) doRequest(req *http.Request) (*http.Response, error) {
-	resp, err := c.opts.HTTPClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusBadRequest {
-		return resp, nil
-	}
-	defer resp.Body.Close()
-
-	var apiErr APIError
-	if err := json.NewDecoder(resp.Body).Decode(&apiErr); err != nil {
-		return nil, err
-	}
-
-	return nil, apiErr
 }

--- a/vertexai/embedding.go
+++ b/vertexai/embedding.go
@@ -100,7 +100,7 @@ func (c *Client) Embed(ctx context.Context, embReq *EmbeddingRequest) ([]*embedd
 		return nil, err
 	}
 
-	resp, err := c.doRequest(req)
+	resp, err := request.Do[APIError](c.opts.HTTPClient, req)
 	if err != nil {
 		return nil, err
 	}

--- a/vertexai/multi_embedding.go
+++ b/vertexai/multi_embedding.go
@@ -80,7 +80,7 @@ func (c *Client) MultiEmbeddings(ctx context.Context, embReq *MultiEmbeddingRequ
 		return nil, err
 	}
 
-	resp, err := c.doRequest(req)
+	resp, err := request.Do[APIError](c.opts.HTTPClient, req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`request.Do` was added. It's a `func` generic in API `error` which helps us clean up unnecessary cruft in the specific client packages.