### PR TITLE
update: renamed openAI model enums and add dimension

### DIFF
--- a/openai/embedding.go
+++ b/openai/embedding.go
@@ -82,6 +82,8 @@ type EmbeddingRequest struct {
 	Model          Model          `json:"model"`
 	User           string         `json:"user"`
 	EncodingFormat EncodingFormat `json:"encoding_format,omitempty"`
+	// NOTE: only supported in V3 and later
+	Dims int `json:"dimensions,omitempty"`
 }
 
 // DataGen is a generic struct used for deserializing vector embeddings.

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -4,9 +4,9 @@ package openai
 type Model string
 
 const (
-	TextAdaV2  Model = "text-embedding-ada-002"
-	Text3Large Model = "text-embedding-3-large"
-	Text3Small Model = "text-embedding-3-small"
+	TextAdaV2   Model = "text-embedding-ada-002"
+	TextLargeV3 Model = "text-embedding-3-large"
+	TextSmallV3 Model = "text-embedding-3-small"
 )
 
 // String implements stringer.


### PR DESCRIPTION
The new V3 text embedding models introduced an option dimensions parameter. This adds it to the open AI API payload. We are also renaming the enum variable names for the new models.

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 29ab8105d17e3c801b24add2973dc6f8d3b95006.  | 
|--------|--------|

### Summary:
This PR adds a dimensions field to the `EmbeddingRequest` struct and renames the enum variable names for the new models.

**Key points**:
- Added `Dims` field to `EmbeddingRequest` struct in `openai/embedding.go`.
- Renamed enum variable names for new models in `openai/openai.go`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
