### PR TITLE
chore: Fix typo in embedding.go

### DIFF
--- a/ollama/embedding.go
+++ b/ollama/embedding.go
@@ -17,14 +17,14 @@ type EmbeddingRequest struct {
 	Model  string `json:"model"`
 }
 
-// EmbedddingResponse received from API.
-type EmbedddingResponse struct {
+// EmbeddingResponse received from API.
+type EmbeddingResponse struct {
 	Embedding []float64 `json:"embedding"`
 }
 
 // ToEmbeddings converts the API response,
 // into a slice of embeddings and returns it.
-func (e *EmbedddingResponse) ToEmbeddings() ([]*embeddings.Embedding, error) {
+func (e *EmbeddingResponse) ToEmbeddings() ([]*embeddings.Embedding, error) {
 	floats := make([]float64, len(e.Embedding))
 	copy(floats, e.Embedding)
 	return []*embeddings.Embedding{
@@ -58,7 +58,7 @@ func (c *Client) Embed(ctx context.Context, embReq *EmbeddingRequest) ([]*embedd
 	}
 	defer resp.Body.Close()
 
-	e := new(EmbedddingResponse)
+	e := new(EmbeddingResponse)
 	if err := json.NewDecoder(resp.Body).Decode(e); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Hey I just came across your awesome work, thanks for sharing btw. 
Just noticed a typo and that's the best I can contribute yet :)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes typo in `EmbeddingResponse` struct and related function names in `embedding.go`.
> 
>   - **Typo Fix**:
>     - Corrects `EmbedddingResponse` to `EmbeddingResponse` in `embedding.go`.
>     - Updates `ToEmbeddings()` function signature to use `EmbeddingResponse`.
>     - Updates instantiation of `EmbeddingResponse` in `Embed()` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=milosgajdos%2Fgo-embeddings&utm_source=github&utm_medium=referral)<sup> for 9fb53b2962536c11657eaae75ca44d152309d2ad. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->