### PR TITLE
Bump cache action in GHA workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
         echo "::set-output name=go_cache::$(go env GOCACHE)"
 
     - name: Cache the build cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ steps.vars.outputs.go_cache }}
         key: ${{ runner.os }}-${{ matrix.go }}-go-ci-${{ hashFiles('**/go.sum') }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump `actions/cache` from `v2` to `v4` in GitHub Actions workflow for caching.
> 
>   - **GitHub Actions**:
>     - Bump `actions/cache` from `v2` to `v4` in `.github/workflows/ci.yaml` for caching the build cache.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=milosgajdos%2Fgo-embeddings&utm_source=github&utm_medium=referral)<sup> for 6ac29a387c16b9fa22d7cd226e6acd2794192c40. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->