### PR TITLE
Bump Go and golangci versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,8 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         go:
-          - '1.21'
-          - '1.22'
+          - '1.23'
+          - '1.24'
 
     steps:
 
@@ -68,8 +68,8 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         go:
-          - '1.21'
-          - '1.22'
+          - '1.23'
+          - '1.24'
 
     steps:
 
@@ -84,4 +84,4 @@ jobs:
     - name: Run linter
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.58
+        version: v1.64

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,7 @@ linters:
     - errname
     - gocritic
     - tparallel
-    - tenv
+    - usetesting
     - unconvert
     - whitespace
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/milosgajdos/go-embeddings
 
-go 1.23.0
+go 1.23
 
 toolchain go1.24.1
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/milosgajdos/go-embeddings
 
-go 1.23
+go 1.23.0
+
+toolchain go1.24.1
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.27.0
@@ -28,7 +30,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/net v0.33.0 // indirect
+	golang.org/x/net v0.36.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/milosgajdos/go-embeddings
 
-go 1.21
+go 1.23
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
-golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
-golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
+golang.org/x/net v0.36.0 h1:vWF2fRbw4qslQsQzgFqZff+BItCvGFQqKzKIzx1rmoA=
+golang.org/x/net v0.36.0/go.mod h1:bFmbeoIPfrw4sMHNhb4J9f6+tPziuGjq7Jk/38fxi1I=
 golang.org/x/oauth2 v0.15.0 h1:s8pnnxNVzjWyrvYdFUQq5llS1PX2zhPXmccZv99h7uQ=
 golang.org/x/oauth2 v0.15.0/go.mod h1:q48ptWNTY5XWf+JNten23lcvHpLJ0ZSxF5ttTHKVCAM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update Go and golangci-lint versions in CI, modify linter configuration, and update a dependency version.
> 
>   - **CI Workflow**:
>     - Update Go versions from `1.21` and `1.22` to `1.23` and `1.24` in `ci.yaml`.
>     - Update `golangci-lint` version from `v1.58` to `v1.64` in `ci.yaml`.
>   - **Linter Configuration**:
>     - Replace `tenv` with `usetesting` in `.golangci.yml`.
>   - **Dependencies**:
>     - Update `golang.org/x/net` from `v0.33.0` to `v0.36.0` in `go.mod` and `go.sum`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=milosgajdos%2Fgo-embeddings&utm_source=github&utm_medium=referral)<sup> for a689749ca0a0949bc4a460e2818ae3687cc56a06. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->